### PR TITLE
Add modalSlice id tests

### DIFF
--- a/__tests__/modalSlice.test.ts
+++ b/__tests__/modalSlice.test.ts
@@ -1,0 +1,21 @@
+import { modalSlice, openModal } from '../src/store/modal/modalSlice';
+
+describe('modalSlice', () => {
+  it('sets state.id to 0 when opened with id 0', () => {
+    const initialState = modalSlice.getInitialState();
+    const nextState = modalSlice.reducer(
+      initialState,
+      openModal({ show: true, contentName: '', id: 0 })
+    );
+    expect(nextState.id).toBe(0);
+  });
+
+  it('clears state.id when closed', () => {
+    const initialState = { ...modalSlice.getInitialState(), id: 5 };
+    const nextState = modalSlice.reducer(
+      initialState,
+      openModal({ show: false, contentName: '' })
+    );
+    expect(nextState.id).toBeUndefined();
+  });
+});

--- a/src/store/modal/modalSlice.ts
+++ b/src/store/modal/modalSlice.ts
@@ -20,8 +20,10 @@ export const modalSlice = createSlice({
       console.log("dispathch!!!");
       state.show = action.payload.show;
       state.contentName = action.payload.contentName;
-      if (action.payload.id) {
+      if (action.payload.id !== undefined) {
         state.id = action.payload.id;
+      } else {
+        state.id = undefined;
       }
     },
   },


### PR DESCRIPTION
## Summary
- update `openModal` reducer to reset `state.id` when no id provided
- add tests for modalSlice behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480aaae894832d91f0f32fcb3178e4